### PR TITLE
fix(fetch): use `proxyRequest` instead of `$fetch` to resolve Internal Server Error

### DIFF
--- a/packages/fetch/src/runtime/server-middleware.ts
+++ b/packages/fetch/src/runtime/server-middleware.ts
@@ -1,11 +1,4 @@
-import {
-  defineEventHandler,
-  getRequestHeaders,
-  readBody,
-  parseCookies,
-  getMethod,
-  getQuery,
-} from 'h3'
+import { defineEventHandler, getProxyRequestHeaders, parseCookies, proxyRequest } from 'h3'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: resolved with Nuxt
 import { useRuntimeConfig } from '#imports'
@@ -17,23 +10,22 @@ const { nuxtFetch } = useRuntimeConfig()
 export default defineEventHandler(async (event: H3Event) => {
   if (event.node.req.url?.startsWith(nuxtFetch.baseApi)) {
     const url = `${nuxtFetch.serviceUrl}${event.node.req.url}`
-    const method = getMethod(event)
-    const query = getQuery(event)
-    const headers = getRequestHeaders(event)
+    const headers = getProxyRequestHeaders(event)
     const cookies = parseCookies(event)
-    let body = null
     headers['Authorization'] = cookies[nuxtFetch.authorization || 'access_token']
-    delete headers['host']
-    if ('GET' !== method.toUpperCase()) {
-      body = await readBody(event)
-    }
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore: resolved with Nuxt
-    return $fetch(url, {
-      method,
-      params: query,
+
+    /**
+     * fix: Use proxyRequest instead of $fetch to resolve Internal Server Error (#3)
+     *
+     * note:
+     * 当删除 headers 中的 connection 字段之后错误不再出现
+     * 也许是 h3 的设定或 bug
+     * 在 https://github.com/unjs/h3/issues/375 中有提到相关的错误
+     *
+     * TODO: 目前问题如何出现的尚未明确，仍需注意此处会发生未知的错误。
+     * -------------------------- */
+    return proxyRequest(event, url, {
       headers,
-      body,
     })
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue
resolves #3 

### 📦 Package of change

- [x] @spruce-hub/nuxt-fetch
- [ ] @spruce-hub/nuxt-route

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
使用 `proxyRequest` 代替 `$fetch` 以解决内部服务器错误的问题

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
