### PR TITLE
feat(fetch): support retrieving API host from environment variables

### DIFF
--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -18,10 +18,15 @@ export default defineNuxtConfig({
     nuxtFetch: {
       // 需要代理的路由前缀
       baseApi: '/api',
-      // 目标服务地址
-      serviceUrl: 'http://myapi.com',
+
       // 从 cookie 中获取名为 access_token 的值并写入请求头 Authorization 中
       authorization: 'access_token',
+
+      // 可选，最高优先级，从环境变量中获取目标服务地址
+      apiHostEnv: 'API_HOST', // process.env.API_HOST
+
+      // 可选，当 process.env[apiHostEnv] 为 false，从 apiHostUrl 获取目标服务地址
+      apiHostUrl: 'http://myapi.com/',
     },
   },
 })

--- a/packages/fetch/src/config.ts
+++ b/packages/fetch/src/config.ts
@@ -2,6 +2,7 @@ import type { Options } from './types'
 
 export const defaults: Options = {
   baseApi: '',
-  serviceUrl: '',
   authorization: '',
+  apiHostEnv: '',
+  apiHostUrl: '',
 }

--- a/packages/fetch/src/runtime/server-middleware.ts
+++ b/packages/fetch/src/runtime/server-middleware.ts
@@ -8,8 +8,14 @@ import type { H3Event } from 'h3'
 const { nuxtFetch } = useRuntimeConfig()
 
 export default defineEventHandler(async (event: H3Event) => {
+  /**
+   * feat: Support retrieving API host from environment variables
+   * -------------------------- */
+  const apiHost =
+    process.env[nuxtFetch.apiHostEnv] || nuxtFetch.apiHostUrl || event.node.req.headers.host
+
   if (event.node.req.url?.startsWith(nuxtFetch.baseApi)) {
-    const url = `${nuxtFetch.serviceUrl}${event.node.req.url}`
+    const url = `${apiHost}${event.node.req.url}`
     const headers = {}
 
     const cookies = parseCookies(event)

--- a/packages/fetch/src/types.ts
+++ b/packages/fetch/src/types.ts
@@ -6,17 +6,23 @@ export interface Options {
   baseApi: string
 
   /**
-   * 服务地址
-   * - Example: 'http://api.com'
-   */
-  serviceUrl: string
-
-  /**
    * 授权码
    * - headers['Authorization']
    * - Default: Cookies['access_token']
    */
   authorization?: string
+
+  /**
+   * 可选，最高优先级，从环境变量中获取目标服务地址
+   * @example { apiHostEnv: 'API_HOST' } // process.env.API_HOST
+   */
+  apiHostEnv?: string
+
+  /**
+   * 可选，当 process.env[apiHostEnv] 为 false，从 apiHostUrl 获取目标服务地址
+   * @example { apiHostUrl: 'http://myapi.com/' } // http://myapi.com/
+   */
+  apiHostUrl?: string
 }
 
 export {}


### PR DESCRIPTION
### 🔗 Linked issue

### 📦 Package of change

- [x] @spruce-hub/nuxt-fetch
- [ ] @spruce-hub/nuxt-route

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
由于 Nuxt 构建过程中会将 nuxt.config 配置对象静态化，为达到动态获取和更新 API host，在 `@spruce-hub/nuxt-fetch` 添加读取环境变量的能力

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
